### PR TITLE
Adding Pillow (~=8.2.0) to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyAutoGUI~=0.9.52
 playsound~=1.2.2
 applescript~=2021.2.9
 psutil~=5.8.0
+Pillow~=8.2.0


### PR DESCRIPTION
Screenshotting breaks unless the Pillow library is available; adding it to requirements.txt.